### PR TITLE
Updating basis function calculation and minor corrections

### DIFF
--- a/basismixer/basisfunctions.py
+++ b/basismixer/basisfunctions.py
@@ -215,6 +215,8 @@ def grace_basis(part):
     for i, n in enumerate(notes):
         if n["duration_beat"] == 0:
             n_grace = np.where((notes["onset_beat"] == n["onset_beat"]) & (notes["duration_beat"]==0))[0].shape[0]
+            # or
+            # n_grace = np.nonzero(ensure_notearray(part, include_grace_notes=True)["is_grace"])
             W[i, 0] = 1
             W[i, 1] = n_grace
             # W[i, 2] = n_grace - sum(1 for _ in n.iter_grace_seq()) + 1

--- a/basismixer/basisfunctions.py
+++ b/basismixer/basisfunctions.py
@@ -659,7 +659,7 @@ def vertical_neighbor_basis(part):
 
     W = np.empty((len(notes), len(names)))
     for i, n in enumerate(notes):
-        neighbors = notes[np.where(notes[onset_beat] == n["onset_beat"])]["pitch"]
+        neighbors = notes[np.where(notes["onset_beat"] == n["onset_beat"])]["pitch"]
         max_pitch = np.max(neighbors)
         min_pitch = np.min(neighbors)
         W[i, 0] = len(neighbors) - 1

--- a/basismixer/predictive_models/train.py
+++ b/basismixer/predictive_models/train.py
@@ -104,12 +104,12 @@ class NNTrainer(ABC):
             out_vars.append(target.var((0, 1)).unsqueeze(0))
             out_sizes.append(torch.prod(torch.tensor(target.shape[:-1])))
 
-        in_means = torch.cat(in_means, axis=0)
-        in_vars = torch.cat(in_vars, axis=0)
+        in_means = torch.cat(in_means, dim=0)
+        in_vars = torch.cat(in_vars, dim=0)
         in_sizes = torch.tensor(in_sizes).to(self.device).type(self.dtype)
 
-        out_means = torch.cat(out_means, axis=0)
-        out_vars = torch.cat(out_vars, axis=0)
+        out_means = torch.cat(out_means, dim=0)
+        out_vars = torch.cat(out_vars, dim=0)
         out_sizes = torch.tensor(out_sizes).to(self.device).type(self.dtype)
 
         in_N = in_sizes.sum().to(self.device).type(self.dtype)


### PR DESCRIPTION
### Corrections mainly on basis function computation.

- Corrected `part.notes_tied` to `ensure_notearray(part)` to account for Part lists and Part Groups. 
- Fixed `torch.cat(x, axis=1)` to `torch.cat(x, dim=1)`.
- Proposing more recent solutions from partitura dev, in particular with `ensure_notearray(part, include_grace_notes=True)` for grace note basis functions.